### PR TITLE
fix #5856

### DIFF
--- a/src/components/modal/modal.vue
+++ b/src/components/modal/modal.vue
@@ -366,8 +366,8 @@
             },
             visible (val) {
                 if (val === false) {
-                    this.buttonLoading = false;
                     this.timer = setTimeout(() => {
+                        this.buttonLoading = false;
                         this.wrapShow = false;
                         this.removeScrollEffect();
                     }, 300);


### PR DESCRIPTION
fix [#5856](https://github.com/iview/iview/issues/5856)
根因：对话框关闭前就调用了this.buttonLoading = false;，而关闭是有动画效果，所以会有短暂按钮恢复为可用
解决方案：把恢复按钮放入到定时器，待对话框彻底消失后再恢复

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
