### PR TITLE
fix #6161

### DIFF
--- a/src/components/auto-complete/auto-complete.vue
+++ b/src/components/auto-complete/auto-complete.vue
@@ -113,7 +113,7 @@
         computed: {
             inputIcon () {
                 let icon = '';
-                if (this.clearable && this.currentValue) {
+                if (this.clearable && this.currentValue && !this.disabled) {
                     icon = 'ios-close';
                 } else if (this.icon) {
                     icon = this.icon;


### PR DESCRIPTION
fix [#6161](https://github.com/iview/iview/issues/6161)
inputIcon没有判断disabled属性，导致在禁用时也能清空内容

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
