### PR TITLE
fix #5213

### DIFF
--- a/src/components/select/select.vue
+++ b/src/components/select/select.vue
@@ -704,9 +704,11 @@
                 const {getInitialValue, getOptionData, publicValue, values} = this;
 
                 this.checkUpdateStatus();
-
+                
+                const vModelValue = (publicValue && this.labelInValue) ?
+                    (this.multiple ? publicValue.map(({value}) => value) : publicValue.value) : publicValue;
                 if (value === '') this.values = [];
-                else if (checkValuesNotEqual(value,publicValue,values)) {
+                else if (checkValuesNotEqual(value,vModelValue,values)) {
                     this.$nextTick(() => this.values = getInitialValue().map(getOptionData).filter(Boolean));
                     this.dispatch('FormItem', 'on-form-change', this.publicValue);
                 }


### PR DESCRIPTION
fix [#5213](https://github.com/iview/iview/issues/5213)
1.如果labelInValue等于true,那么publicValue的值就是label 和 value 对象，再接下来的else分支判断值是否相等就会错误的判断为不相等，导致重新初始值，覆盖掉了原来的值。
2.重新覆盖值的逻辑是通过getOptionData函数构造数组，但每次从新搜索得到的option集合就回存在和上一次不一样的情况，就会存在丢失原来值的情况

<!-- 目前请提交 PR 到 2.0 分支 | Please send PR to 2.0 branch -->
<!-- 请不要提交 dist 的内容 | Please do not commit dist file -->
<!-- 请先运行 npm install 和 npm test，通过测试后再提交您的 pr -->
<!-- Please run `npm install` and `npm test` to test your changes before submitting a pull request -->
